### PR TITLE
Workaround for bug #6

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,4 @@ source 'https://rubygems.org'
 
 gem 'foreman'
 gem 'rest-client'
+gem 'wait'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,6 +9,7 @@ GEM
     rest-client (1.6.7)
       mime-types (>= 1.16)
     thor (0.18.1)
+    wait (0.5.1)
 
 PLATFORMS
   ruby
@@ -16,3 +17,4 @@ PLATFORMS
 DEPENDENCIES
   foreman
   rest-client
+  wait

--- a/lib/mint.rb
+++ b/lib/mint.rb
@@ -30,4 +30,21 @@ class Mint
   def csv
     RestClient.get(CSV_URL, :cookies => @cookies)
   end
+
+  # A (hopefully) temporary workaround for bug #6:
+  #
+  #   https://github.com/toddmazierski/mint-exporter/issues/6
+  #
+  # Attempts to download the CSV up to 10 times, pausing for 5 seconds between
+  # each attempt.
+  def csv_with_bug_6_workaround
+    wait = Wait.new(
+      :attempts => 10,
+      :timeout  => 60,
+      :delay    => 5,
+      :rescue   => RestClient::ResourceNotFound
+    )
+
+    wait.until { csv }
+  end
 end

--- a/mint-exporter.rb
+++ b/mint-exporter.rb
@@ -9,4 +9,4 @@ credentials.validate!
 
 mint = Mint.new(credentials)
 mint.authenticate
-puts mint.csv
+puts mint.csv_with_bug_6_workaround


### PR DESCRIPTION
A (hopefully) temporary workaround for bug #6. Attempts to download the CSV up to 10 times, pausing for 5 seconds between each attempt.

@c4mb0t, mind giving this a spin? Thank you.
