### PR TITLE
Fix bug where error wasn't coerced to string

### DIFF
--- a/lib/mint/session.rb
+++ b/lib/mint/session.rb
@@ -6,7 +6,7 @@ module Mint
       response = request
 
       error = JSON.parse(response)['error']
-      raise(error) if error
+      raise(error.to_s) if error
 
       @cookies = response.cookies
     end

--- a/spec/lib/mint/session_spec.rb
+++ b/spec/lib/mint/session_spec.rb
@@ -1,0 +1,17 @@
+require 'spec_helper'
+
+describe Mint::Session do
+  describe '#create!' do
+    let(:session) { Mint::Session.new }
+
+    context 'error in response' do
+      let(:response) { '{"error": {"the_system": "is_down"}}' }
+
+      before { allow(session).to receive(:request).and_return(response) }
+
+      it 'raises an exception' do
+        expect { session.create! }.to raise_error '{"the_system"=>"is_down"}'
+      end
+    end
+  end
+end


### PR DESCRIPTION
As originally reported by @za3k in #14. Thanks!